### PR TITLE
Fix to display line number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,5 @@ go:
   - 1.10.x
   - 1.11.x
   - 1.12.x
-before_install:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.12.3
 script:
-  - golangci-lint run
   - go test -v ./...

--- a/_samples/main.go
+++ b/_samples/main.go
@@ -44,8 +44,8 @@ bb	bb	bb
 #### 見出し4
 
 
-##### 見出し5
-`
+##### 見出し5`
+
 	err := goss.Run(data)
 	if err != nil {
 		fmt.Println(err)

--- a/drawer/drawer.go
+++ b/drawer/drawer.go
@@ -119,7 +119,9 @@ func (d *Drawer) pageUpWindow() {
 }
 
 func (d *Drawer) pageEnd() {
-	d.offset = d.max - d.limit
+	if d.max > d.limit {
+		d.offset = d.max - d.limit + 1
+	}
 }
 
 func (d *Drawer) pageTop() {

--- a/drawer/drawer.go
+++ b/drawer/drawer.go
@@ -33,6 +33,10 @@ func New(text string, offset int, max int, rowMax int) *Drawer {
 	}
 }
 
+func (d *Drawer) Max() int {
+	return d.max
+}
+
 func (d *Drawer) Offset() int {
 	return d.offset
 }

--- a/drawer/drawer_test.go
+++ b/drawer/drawer_test.go
@@ -145,7 +145,7 @@ func TestPageEnd(t *testing.T) {
 	d.SetLimit(2)
 	drawer.PageEnd(d)
 
-	if d.Offset() != (3 - 2) {
+	if d.Offset() != (3 - 1) {
 		t.Errorf("expected=1, got=%d", d.Offset())
 	}
 }

--- a/viewer/viewer.go
+++ b/viewer/viewer.go
@@ -128,8 +128,13 @@ func (v *Viewer) write() {
 
 func (v *Viewer) writeLineNumber(height int) {
 	offsetInt := v.drawer.Offset()
+	max := v.drawer.Max()
 
 	for i := 1; i <= height+1; i++ {
+		if offsetInt > max+1 {
+			break
+		}
+
 		offsetStr := strconv.Itoa(offsetInt)
 		for _, r := range offsetStr {
 			col, row := v.drawer.Position()

--- a/viewer/viewer.go
+++ b/viewer/viewer.go
@@ -110,17 +110,7 @@ func (v *Viewer) write() {
 	str, _ := v.drawer.GetContent()
 	width, height := v.tui.Size()
 
-	offsetInt := v.drawer.Offset()
-	for i := 1; i <= height+1; i++ {
-		offsetStr := strconv.Itoa(offsetInt)
-		for _, r := range offsetStr {
-			col, row := v.drawer.Position()
-			v.tui.SetContent(col, row-1, r, nil, v.lineNumStyle)
-			v.drawer.AddPosition(r)
-		}
-		v.drawer.Break()
-		offsetInt++
-	}
+	v.writeLineNumber(height)
 
 	v.drawer.Reset()
 	for _, s := range str {
@@ -133,5 +123,20 @@ func (v *Viewer) write() {
 		if height < row {
 			break
 		}
+	}
+}
+
+func (v *Viewer) writeLineNumber(height int) {
+	offsetInt := v.drawer.Offset()
+
+	for i := 1; i <= height+1; i++ {
+		offsetStr := strconv.Itoa(offsetInt)
+		for _, r := range offsetStr {
+			col, row := v.drawer.Position()
+			v.tui.SetContent(col, row-1, r, nil, v.lineNumStyle)
+			v.drawer.AddPosition(r)
+		}
+		v.drawer.Break()
+		offsetInt++
 	}
 }

--- a/viewer/viewer_test.go
+++ b/viewer/viewer_test.go
@@ -25,12 +25,15 @@ func TestWrite(t *testing.T) {
 
 	tui.Show()
 
-	expected := ` 1   test1                    
- 2   test2  test3    test4    
- 3   test5                    
-                              
-                              
-`
+	// trim end space if use heredoc
+	slice := []string{
+		" 1   test1                    \n",
+		" 2   test2  test3    test4    \n",
+		" 3   test5                    \n",
+		"                              \n",
+		"                              \n",
+	}
+	expected := slice[0] + slice[1] + slice[2] + slice[3] + slice[4]
 
 	actual := getString(tui)
 

--- a/viewer/viewer_test.go
+++ b/viewer/viewer_test.go
@@ -1,9 +1,10 @@
 package viewer_test
 
 import (
+	"testing"
+
 	"github.com/gdamore/tcell"
 	"github.com/wasanx25/goss/viewer"
-	"testing"
 )
 
 func TestWrite(t *testing.T) {
@@ -27,8 +28,8 @@ func TestWrite(t *testing.T) {
 	expected := ` 1   test1                    
  2   test2  test3    test4    
  3   test5                    
- 4                            
- 5                            
+                              
+                              
 `
 
 	actual := getString(tui)


### PR DESCRIPTION
## Overview

- [x] unnecessary display line number when it is left over rows in term
- [x] when type `shift + g` , display minus number